### PR TITLE
Fix psutil installation for tests

### DIFF
--- a/pymorphy2/utils.py
+++ b/pymorphy2/utils.py
@@ -12,11 +12,7 @@ def get_mem_usage():
     """
     import psutil
     proc = psutil.Process(os.getpid())
-    try:
-        return proc.memory_info().rss
-    except AttributeError:
-        # psutil < 2.x
-        return proc.get_memory_info()[0]
+    return proc.memory_info().rss
 
 
 def combinations_of_all_lengths(it):

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps=
     pytest-cov
     tqdm
     coverage >= 4.0
+    psutil
 
     {py37,py38,py39,py310,py311}-fast: lxml
 
@@ -22,7 +23,7 @@ commands=
 
     fast: pip install pymorphy2[fast]
 
-    py37,py38,py39,py310,py311,pypy3: pip install psutil
+    ; py37,py38,py39,py310,py311,pypy3: pip install psutil
     py37,py38,py39,py310,py311,pypy3: pymorphy dict mem_usage
 
     py.test \

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ commands=
 
     fast: pip install pymorphy2[fast]
 
-    ; py37,py38,py39,py310,py311,pypy3: pip install psutil
     py37,py38,py39,py310,py311,pypy3: pymorphy dict mem_usage
 
     py.test \


### PR DESCRIPTION
Drop support of psutil older than 2 version. [psutil 2.0.0](https://pypi.org/project/psutil/2.0.0/#files) was released 10 mar 2014 and supported Python versions up to 3.4. There's no need to support such ancient versions.

No psutil version specification because it's just impossible to install such old versions of psutil on modern versions of Python.